### PR TITLE
Add dot customization options

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,26 +71,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -119,10 +119,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -142,7 +142,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.0"
+    version: "2.1.1"
   source_span:
     dependency: transitive
     description:
@@ -187,18 +187,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/lib/src/appearance.dart
+++ b/lib/src/appearance.dart
@@ -25,7 +25,7 @@ class CircularSliderAppearance {
   static const double _defaultShadowMaxOpacity = 0.2;
   static const Color _defaultDotColor = Colors.white;
   static const Color _defaultDotStrokeColor = Colors.white;
-  static const Color _defaultDotStrokeWidth = 0.0;
+  static const double _defaultDotStrokeWidth = 0.0;
 
   String _defaultPercentageModifier(double value) {
     final roundedValue = (value).ceil().toInt().toString();
@@ -104,7 +104,7 @@ class CircularSliderAppearance {
       _customShadowMaxOpacity ?? _defaultShadowMaxOpacity;
   double? get shadowStep => _customShadowStep;
   Color get dotColor => _customDotColor ?? _defaultDotColor;
-  Color get dotStrokeColor => _customDotStrokeColor ?? _defualtDotStrokeColor;
+  Color get dotStrokeColor => _customDotStrokeColor ?? _defaultDotStrokeColor;
   double get dotStrokeWidth => _customDotStrokeWidth ?? _defaultDotStrokeWidth;
 
   String? get _topLabelText => infoProperties?.topLabelText;

--- a/lib/src/appearance.dart
+++ b/lib/src/appearance.dart
@@ -26,6 +26,8 @@ class CircularSliderAppearance {
   static const Color _defaultDotColor = Colors.white;
   static const Color _defaultDotStrokeColor = Colors.white;
   static const double _defaultDotStrokeWidth = 0.0;
+  static const bool _defaultShowDotShadow = false;
+  static const Color _defaultDotShadowColor = Colors.black;
 
   String _defaultPercentageModifier(double value) {
     final roundedValue = (value).ceil().toInt().toString();
@@ -84,6 +86,8 @@ class CircularSliderAppearance {
   Color? get _customDotColor => customColors?.dotColor;
   Color? get _customDotStrokeColor => customColors?.dotStrokeColor;
   double? get _customDotStrokeWidth => customColors?.dotStrokeWidth;
+  bool? get _customShowDotShadow => customColors?.showDotShadow;
+  Color? get _customDotShadowColor => customColors?.dotShadowColor;
   bool? get _hideShadow => customColors?.hideShadow;
 
   Color get trackColor => _customTrackColor ?? _defaultTrackColor;
@@ -106,6 +110,8 @@ class CircularSliderAppearance {
   Color get dotColor => _customDotColor ?? _defaultDotColor;
   Color get dotStrokeColor => _customDotStrokeColor ?? _defaultDotStrokeColor;
   double get dotStrokeWidth => _customDotStrokeWidth ?? _defaultDotStrokeWidth;
+  bool get showDotShadow => _customShowDotShadow ?? _defaultShowDotShadow;
+  Color get dotShadowColor => _customDotShadowColor ?? _defaultDotShadowColor;
 
   String? get _topLabelText => infoProperties?.topLabelText;
   String? get _bottomLabelText => infoProperties?.bottomLabelText;
@@ -191,6 +197,8 @@ class CustomSliderColors {
   final Color? dotColor;
   final Color? dotStrokeColor;
   final double? dotStrokeWidth;
+  final bool? showDotShadow;
+  final Color? dotShadowColor;
 
   CustomSliderColors({
     this.trackColor,
@@ -208,6 +216,8 @@ class CustomSliderColors {
     this.dotColor,
     this.dotStrokeColor,
     this.dotStrokeWidth,
+    this.showDotShadow,
+    this.dotShadowColor,
     this.dynamicGradient = false,
   });
 }

--- a/lib/src/appearance.dart
+++ b/lib/src/appearance.dart
@@ -24,6 +24,8 @@ class CircularSliderAppearance {
   static const Color _defaultShadowColor = Color.fromRGBO(44, 87, 192, 1.0);
   static const double _defaultShadowMaxOpacity = 0.2;
   static const Color _defaultDotColor = Colors.white;
+  static const Color _defaultDotStrokeColor = Colors.white;
+  static const Color _defaultDotStrokeWidth = 0.0;
 
   String _defaultPercentageModifier(double value) {
     final roundedValue = (value).ceil().toInt().toString();
@@ -80,6 +82,8 @@ class CircularSliderAppearance {
   double? get _customShadowMaxOpacity => customColors?.shadowMaxOpacity;
   double? get _customShadowStep => customColors?.shadowStep;
   Color? get _customDotColor => customColors?.dotColor;
+  Color? get _customDotStrokeColor => customColors?.dotStrokeColor;
+  double? get _customDotStrokeWidth => customColors?.dotStrokeWidth;
   bool? get _hideShadow => customColors?.hideShadow;
 
   Color get trackColor => _customTrackColor ?? _defaultTrackColor;
@@ -100,6 +104,8 @@ class CircularSliderAppearance {
       _customShadowMaxOpacity ?? _defaultShadowMaxOpacity;
   double? get shadowStep => _customShadowStep;
   Color get dotColor => _customDotColor ?? _defaultDotColor;
+  Color get dotStrokeColor => _customDotStrokeColor ?? _defualtDotStrokeColor;
+  double get dotStrokeWidth => _customDotStrokeWidth ?? _defaultDotStrokeWidth;
 
   String? get _topLabelText => infoProperties?.topLabelText;
   String? get _bottomLabelText => infoProperties?.bottomLabelText;
@@ -183,6 +189,8 @@ class CustomSliderColors {
   final double? shadowMaxOpacity;
   final double? shadowStep;
   final Color? dotColor;
+  final Color? dotStrokeColor;
+  final double? dotStrokeWidth;
 
   CustomSliderColors({
     this.trackColor,
@@ -198,6 +206,8 @@ class CustomSliderColors {
     this.shadowMaxOpacity,
     this.shadowStep,
     this.dotColor,
+    this.dotStrokeColor,
+    this.dotStrokeWidth,
     this.dynamicGradient = false,
   });
 }

--- a/lib/src/curve_painter.dart
+++ b/lib/src/curve_painter.dart
@@ -176,9 +176,16 @@ class _CurvePainter extends CustomPainter {
   }
 
   void _drawHandler(Canvas canvas) {
-    final handlerPaint = Paint()..color = appearance.dotColor;
+    var handlerPaint = Paint()..color = appearance.dotColor;
+    handlerPaint.style = PaintingStyle.fill;
     final handlerPosition = _calculateHandlerPosition();
+
+    var handlerStrokePaint = Paint()..color = appearance.dotStrokeColor;
+    handlerStrokePaint.style = PaintingStyle.stroke;
+    handlerStrokePaint.strokeWidth = appearance.dotStrokeWidth;
+
     canvas.drawCircle(handlerPosition, appearance.handlerSize, handlerPaint);
+    canvas.drawCircle(handlerPosition, appearance.handlerSize, handlerStrokePaint);
   }
 
   Offset _calculateHandlerPosition() {

--- a/lib/src/curve_painter.dart
+++ b/lib/src/curve_painter.dart
@@ -184,8 +184,26 @@ class _CurvePainter extends CustomPainter {
     handlerStrokePaint.style = PaintingStyle.stroke;
     handlerStrokePaint.strokeWidth = appearance.dotStrokeWidth;
 
+    if (appearance.showDotShadow) {
+      canvas.drawShadow(
+        Path()..addOval(
+          Rect.fromCircle(
+            center: handlerPosition,
+            radius: appearance.handlerSize * 1.1,
+          ),
+        ),
+        appearance.dotShadowColor.withValues(alpha: 0.7),
+        4.0, // Shadow elevation
+        true, // Whether the shadow is transparent
+      );
+    }
+
     canvas.drawCircle(handlerPosition, appearance.handlerSize, handlerPaint);
-    canvas.drawCircle(handlerPosition, appearance.handlerSize, handlerStrokePaint);
+    canvas.drawCircle(
+      handlerPosition,
+      appearance.handlerSize,
+      handlerStrokePaint,
+    );
   }
 
   Offset _calculateHandlerPosition() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -71,26 +71,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -119,10 +119,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -180,18 +180,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sleek_circular_slider
 description: A highly customizable circular slider/progress bar & spinner for Flutter.
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/matthewfx/sleek-circular-slider
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sleek_circular_slider
 description: A highly customizable circular slider/progress bar & spinner for Flutter.
-version: 2.1.1
+version: 2.1.0
 homepage: https://github.com/matthewfx/sleek-circular-slider
 
 environment:


### PR DESCRIPTION
This adds `dotStrokeColor`, `dotStrokeWidth`, `showDotShadow`, and `dotShadowColor` to the customization options for the slider.

Non-breaking and all are disabled by default